### PR TITLE
Remove redirect for system requirements link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The app launches a window displaying a map.
 
 ## Requirements
 
-See the Runtime SDK's [system requirements](https://developers.arcgis.com/java/latest/guide/system-requirements-for-quartz.htm).
+See the Runtime SDK's [system requirements](https://developers.arcgis.com/java/latest/guide/system-requirements.htm).
 
 ## Resources
 


### PR DESCRIPTION
Currently, the System Requirements link has URL of `https://developers.arcgis.com/java/latest/guide/system-requirements-for-quartz.htm`, which causes a redirect.

Replace URL with:
`https://developers.arcgis.com/java/latest/guide/system-requirements.htm`