### PR TITLE
Remove deprecated gradle features 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }
@@ -57,8 +57,4 @@ task copyNatives(type: Copy) {
 run {
     dependsOn copyNatives
     mainClassName = 'com.mycompany.app.App'
-}
-
-wrapper {
-    gradleVersion = '5.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR replaces `compile` with `implementation` under dependencies in the build.gradle file, as it will be deprecated in Gradle 7.0.

Based on [this PR](https://github.com/Esri/java-gradle-starter-project/pull/9), I removed the wrapper block, as the gradle version has been updated in the gradle-wrapper.properties. 