### PR TITLE
Fix Gradle 9 warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'application'
     id 'idea'
-    id 'org.openjfx.javafxplugin' version '0.0.14'
+    id 'org.openjfx.javafxplugin' version '0.1.0'
 }
 
 idea {


### PR DESCRIPTION
Version 0.0.14 of the JavaFX plugin was causing Gradle 9 deprecation warnings in the build script.  The new 0.1.0 release resolves this.